### PR TITLE
Various Fixes 2018-05-16 (V2 Docs)

### DIFF
--- a/lib/toc_data.rb
+++ b/lib/toc_data.rb
@@ -5,7 +5,7 @@ def toc_data(page_content)
 
   # get a flat list of headers
   headers = []
-  html_doc.css('h1, h2, h3').each do |header|
+  html_doc.css('h1, h2, h3, h4').each do |header|
     headers.push({
       id: header.attribute('id').to_s,
       content: header.children,
@@ -14,7 +14,7 @@ def toc_data(page_content)
     })
   end
 
-  [3,2].each do |header_level|
+  [4,3,2].each do |header_level|
     header_to_nest = nil
     headers = headers.reject do |header|
       if header[:level] == header_level

--- a/source/includes/_appendix.md
+++ b/source/includes/_appendix.md
@@ -17,7 +17,7 @@ The following datetime formats can be used when querying with a `timestamp` URI 
 - "2006-01-02"
 - "2006-01-02T15:04:05Z"
 
-## Orders
+## Orders Details
 
 | Available Statuses
 | -----------------------
@@ -31,7 +31,7 @@ The following datetime formats can be used when querying with a `timestamp` URI 
 
 Click [HERE](http://help.regfox.com/article/973-registration-statuses-explained) to see a help article explaining these statuses.
 
-## Registrants
+## Registrants Details
 
 | Available Statuses
 | -----------------------
@@ -47,7 +47,7 @@ Click [HERE](http://help.regfox.com/article/973-registration-statuses-explained)
 
 Click [HERE](http://help.regfox.com/article/973-registration-statuses-explained) to see a help article explaining these statuses.
 
-## Tickets
+## Tickets Details
 
 | Available Statuses
 | -----------------------
@@ -60,7 +60,7 @@ Click [HERE](http://help.regfox.com/article/973-registration-statuses-explained)
 
 Click [HERE](http://help.ticketspice.com/article/501-order-statuses-explained) to see a help article explaining these statuses.
 
-## Transactions
+## Transactions Details
 
 ### Statuses
 
@@ -89,7 +89,7 @@ Click [HERE](http://help.regfox.com/article/972-transaction-statuses-explained) 
 | preauth				| A zero dollar transaction used for validating a future payment method
 | chargeback		| Transaction used to report when a credit card holder contacts his bank or credit card company to dispute a charge on his account
 
-## Subscriptions / Reoccurring Payments
+## Subscriptions / Reoccurring Payments Details
 
 Available Statuses | Description
 ------------------ | -------------------------------------------------------
@@ -98,7 +98,7 @@ inactive           | Is inactive and will not process future payments
 canceled           | Is canceled and will no longer process future payments
 completed          | Is completed and will no longer process future payments
 
-## Memberships
+## Memberships Details
 
 | Available Statuses
 | ------------------
@@ -109,7 +109,7 @@ completed          | Is completed and will no longer process future payments
 | purchasing
 | abandoned
 
-## Forms
+## Forms Details
 
 | Available Statuses
 | ------------------
@@ -119,7 +119,7 @@ completed          | Is completed and will no longer process future payments
 | archived
 | deleted
 
-## Webhooks
+## Webhooks Details
 
 ### Statuses
 
@@ -135,7 +135,7 @@ Id   | Available Types
 1    | Standard webhook
 2-20 | Internal webhook types that should not be edited
 
-## Currency
+## Currency Details
 
 Note: additional new currencies can be added at any time.
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -1,16 +1,16 @@
-# Webhooks
+# Webhook
 
 Our webhook system allows you to receive data when certain events happen on your account.
 
 We currently support the following events:
 
-- New Registrations/Orders
+- New Registrations/Orders Notification
 - Subscription/Recurring Notification
 - Reoccurring SMS Donation Notification (Beta)
-- Form Published
-- Inventory Supply
-- Coupons
-- Test
+- Form Published Notification
+- Inventory Supply Notification
+- Coupons Notification
+- Test Notification
 
 ## Control Panel Interface
 

--- a/source/includes/_webhooks_events.md
+++ b/source/includes/_webhooks_events.md
@@ -1,8 +1,8 @@
-## Webhooks Events
+## Webhook Events
 
 These are the system events that are available as webhook triggers.
 
-### Registration
+### Registration Notification
 
 > Example Payload:
 
@@ -175,7 +175,7 @@ Parameter | Default | Description
 name      | string  | The name of the webhook
 appKey    | string  | Self assigned application key (optional)
 
-### Form Publish
+### Form Publish Event
 
 > Example Payload:
 
@@ -468,7 +468,7 @@ text2GiveNumber      | string  | The donation level tied to the campaign
 billing              | object  | Object contains the billing information
 
 
-### Inventory
+### Inventory Notification
 
 > Example Payload:
 
@@ -541,7 +541,7 @@ name      | string  | The name of the webhook
 appKey    | string  | Self assigned application key (optional)
 
 
-### Coupons
+### Coupons Notification
 
 > Example Payload:
 
@@ -635,7 +635,7 @@ valueType | string    | Specifies the discount type - `Percent` or `Fixed`
 value     | string    | Value amount to apply
 
 
-### Test
+### Test Notification
 
 > Example Payload:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -12,7 +12,6 @@ toc_footers:
   - ©2018 Webconnex
 
 includes:
-  - oauth
   - api_v2
   - api_v2_endpoints
   - api_v2_ping

--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -3,7 +3,7 @@
 //= require ./app/_lang
 
 $(function() {
-	loadToc($('#toc'), '.toc-link', '.toc-list-h2, .toc-list-h3', 10);
+	loadToc($('#toc'), '.toc-link', '.toc-list-h2, .toc-list-h3, .toc-list-h4', 10);
   setupLanguages($('body').data('languages'));
   $('.content').imagesLoaded( function() {
     window.recacheHeights();

--- a/source/javascripts/all_nosearch.js
+++ b/source/javascripts/all_nosearch.js
@@ -3,7 +3,7 @@
 //= require ./app/_lang
 
 $(function() {
-  loadToc($('#toc'), '.toc-link', '.toc-list-h2', 10);
+	loadToc($('#toc'), '.toc-link', '.toc-list-h2, .toc-list-h3', 10);
   setupLanguages($('body').data('languages'));
   $('.content').imagesLoaded( function() {
     window.recacheHeights();

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -83,7 +83,16 @@ under the License.
 										    <% h2[:children].each do |h3| %>
 										      <li>
 										        <a href="#<%= h3[:id] %>" class="toc-h3 toc-link" data-title="<%= h2[:content] %>"><%= h3[:content] %></a>
-										      </li>
+														<% if h3[:children].length > 0 %>
+														  <ul class="toc-list-h4">
+														    <% h3[:children].each do |h4| %>
+														      <li>
+														        <a href="#<%= h4[:id] %>" class="toc-h4 toc-link" data-title="<%= h1[:content] %>"><%= h4[:content] %></a>
+														      </li>
+														    <% end %>
+														  </ul>
+														<% end %>
+													</li>
 										    <% end %>
 										  </ul>
 										<% end %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -77,7 +77,16 @@ under the License.
               <ul class="toc-list-h2">
                 <% h1[:children].each do |h2| %>
                   <li>
-                    <a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:content].to_s.parameterize %>"><%= h2[:content] %></a>
+										<a href="#<%= h2[:id] %>" class="toc-h2 toc-link" data-title="<%= h2[:content].to_s.parameterize %>"><%= h2[:content] %></a>
+										<% if h2[:children].length > 0 %>
+										  <ul class="toc-list-h3">
+										    <% h2[:children].each do |h3| %>
+										      <li>
+										        <a href="#<%= h3[:id] %>" class="toc-h3 toc-link" data-title="<%= h2[:content] %>"><%= h3[:content] %></a>
+										      </li>
+										    <% end %>
+										  </ul>
+										<% end %>
                   </li>
                 <% end %>
               </ul>

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -28,6 +28,7 @@ $examples-bg: #2E3336 !default;
 $code-bg: #1E2224 !default;
 $code-annotation-bg: #191D1F !default;
 $nav-subitem-bg: #1E2224 !default;
+$nav-nested-subitem-bg: #343839 !default;
 $nav-active-bg: #0F75D4 !default;
 $nav-active-parent-bg: #1E2224 !default; // parent links of the current section
 $lang-select-border: #000 !default;
@@ -60,7 +61,7 @@ $logo-margin: 0px !default; // margin below logo
 $main-padding: 28px !default; // padding to left and right of content & examples
 $nav-padding: 15px !default; // padding to left and right of navbar
 $nav-v-padding: 10px !default; // padding used vertically around search boxes and results
-$nav-indent: 10px !default; // extra padding for ToC subitems
+$nav-indent: 5px !default; // extra padding for ToC subitems
 $code-annotation-padding: 13px !default; // padding inside code annotations
 $h1-margin-bottom: 21px !default; // padding under the largest header tags
 $tablet-width: 930px !default; // min width before reverting to tablet size

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -185,6 +185,16 @@ html, body {
 	  font-size: 12px;
 	}
 
+	.toc-list-h4 {
+		display: none;
+		background-color: $nav-nested-subitem-bg;
+	}
+
+	.toc-h4 {
+		padding-left: $nav-padding + $nav-padding + $nav-indent + $nav-indent;
+		font-size: 12px;
+	}
+
   .toc-footer {
     padding: 1em 0;
     margin-top: 1em;
@@ -354,6 +364,7 @@ html, body {
 	& > h1,
 	& > h2,
 	& > h3,
+	& > h4,
 	& > div {
 	  clear: both;
 	}

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -175,6 +175,16 @@ html, body {
     font-size: 12px;
   }
 
+	.toc-list-h3 {
+	  display: none;
+	  background-color: $nav-subitem-bg;
+	}
+
+	.toc-h3 {
+	  padding-left: $nav-padding + $nav-padding + $nav-indent;
+	  font-size: 12px;
+	}
+
   .toc-footer {
     padding: 1em 0;
     margin-top: 1em;
@@ -340,10 +350,13 @@ html, body {
     padding-left: $main-padding + 15px;
   }
 
-  // the div is the tocify hidden div for placeholding stuff
-  &>h1, &>h2, &>div {
-    clear:both;
-  }
+	// the div is the tocify hidden div for placeholding stuff
+	& > h1,
+	& > h2,
+	& > h3,
+	& > div {
+	  clear: both;
+	}
 
   h1 {
     @extend %header-font;


### PR DESCRIPTION
# Description
- Fixes h3, h4 nav nesting lost in Slate 2.0 upgrade
- Rename items to not conflict. ie.. Clicking "API Ref - Webhooks" would go to "Appenedix - Webhooks"
- Removed OAuth, Can add back latter when we support it.